### PR TITLE
バグ修正: 本番環境で出ているエラーを修正

### DIFF
--- a/src/containers/DevTools.js
+++ b/src/containers/DevTools.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createDevTools } from 'redux-devtools';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -7,10 +6,17 @@ import LogMonitor from 'redux-devtools-log-monitor';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import DockMonitor from 'redux-devtools-dock-monitor';
 
-const DevTools = createDevTools(
-  <DockMonitor toggleVisibilityKey="ctrl-h" changePositionKey="ctrl-q">
-    <LogMonitor theme="tomorrow" />
-  </DockMonitor>,
-);
+const inDevelopment = process.env.NODE_ENV === 'development';
+
+const buildDevTools = () =>
+  createDevTools(
+    <DockMonitor toggleVisibilityKey="ctrl-h" changePositionKey="ctrl-q">
+      <LogMonitor theme="tomorrow" />
+    </DockMonitor>,
+  );
+
+const DevTools = inDevelopment
+  ? buildDevTools()
+  : () => <div style={{ display: 'none' }} />;
 
 export default DevTools;


### PR DESCRIPTION
本番環境で、DevToolsを読み込んでないのに利用しようとするため、エラーが出ているのを修正。

<img width="1378" alt="mako_labo" src="https://user-images.githubusercontent.com/92595/40175789-451fcff0-5a14-11e8-864c-309330778586.png">

確認方法

```
yarn build
npx serve -s build
```

ブラウザで表示して確認できます。